### PR TITLE
fix-ci(general): 💚  Set RUNNING_IN_CI variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,5 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNNING_IN_CI: true
         run: npx semantic-release


### PR DESCRIPTION
Sets the RUNNING_IN_CI variable to prevent commitlint from failing semantic release commits in CI